### PR TITLE
Turn error handler

### DIFF
--- a/Bot.AspNet.WebApp/SampleBot.cs
+++ b/Bot.AspNet.WebApp/SampleBot.cs
@@ -33,6 +33,11 @@ namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
 
             if (activity.Type == ActivityTypes.Message)
             {
+                if (activity.Text == "self destruct")
+                {
+                    throw new System.Exception("Self destruct triggered... BOOM!");
+                }
+
                 state.EchoCount++;
 
                 await turnContext.SendActivityAsync($"[{state.EchoCount}] You said: {activity.Text}", cancellationToken: cancellationToken);

--- a/Bot.AspNet.WebApp/Startup.cs
+++ b/Bot.AspNet.WebApp/Startup.cs
@@ -37,15 +37,7 @@ namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
             services.AddBot<SampleBot>(options =>
             {
                 options.UseBotConfigurationEndpointCredentialsFromFolder(_hostingEnvironment.ContentRootPath, endpointName: _hostingEnvironment.EnvironmentName);
-
-                var logger = _loggerFactory.CreateLogger<SampleBot>();
-
-                options.OnTurnError = async (context, exception) =>
-                {
-                    logger.LogError("An unhandled exception occurred in this turn: {Exception}", exception);
-
-                    await context.SendActivityAsync("Sorry, it looks like something went wrong.");
-                };
+                options.LogUnhandledTurnExceptions(_loggerFactory.CreateLogger<SampleBot>(), "Sorry, it looks like something went wrong.");
             });
         }
 

--- a/Bot.AspNet.WebApp/Startup.cs
+++ b/Bot.AspNet.WebApp/Startup.cs
@@ -4,12 +4,14 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
 {
     public class Startup
     {
         private readonly IHostingEnvironment _hostingEnvironment;
+        private ILoggerFactory _loggerFactory;
 
         public Startup(IHostingEnvironment hostingEnvironment)
         {
@@ -34,11 +36,22 @@ namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
             services.AddBot<SampleBot>(options =>
             {
                 options.UseBotConfigurationEndpointCredentialsFromFolder(_hostingEnvironment.ContentRootPath, endpointName: _hostingEnvironment.EnvironmentName);
+
+                var logger = _loggerFactory.CreateLogger<SampleBot>();
+
+                options.OnTurnError = async (context, exception) =>
+                {
+                    logger.LogError($"Exception caught : {exception}");
+
+                    await context.SendActivityAsync("Sorry, it looks like something went wrong.");
+                };
             });
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
+            _loggerFactory = loggerFactory;
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/Bot.AspNet.WebApp/Startup.cs
+++ b/Bot.AspNet.WebApp/Startup.cs
@@ -11,11 +11,12 @@ namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
     public class Startup
     {
         private readonly IHostingEnvironment _hostingEnvironment;
-        private ILoggerFactory _loggerFactory;
+        private readonly ILoggerFactory _loggerFactory;
 
-        public Startup(IHostingEnvironment hostingEnvironment)
+        public Startup(IHostingEnvironment hostingEnvironment, ILoggerFactory loggerFactory)
         {
             _hostingEnvironment = hostingEnvironment ?? throw new System.ArgumentNullException(nameof(hostingEnvironment));
+            _loggerFactory = loggerFactory ?? throw new System.ArgumentNullException(nameof(loggerFactory));
         }
 
         public void ConfigureServices(IServiceCollection services)
@@ -41,17 +42,15 @@ namespace HackedBrain.BotBuilder.Samples.IdiomaticNetCore.BotWebApp
 
                 options.OnTurnError = async (context, exception) =>
                 {
-                    logger.LogError($"Exception caught : {exception}");
+                    logger.LogError("An unhandled exception occurred in this turn: {Exception}", exception);
 
                     await context.SendActivityAsync("Sorry, it looks like something went wrong.");
                 };
             });
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
         {
-            _loggerFactory = loggerFactory;
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/BotBuilder.Extensions/BotFrameworkOptionsTurnErrorExtensions.cs
+++ b/BotBuilder.Extensions/BotFrameworkOptionsTurnErrorExtensions.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+
+namespace Microsoft.Bot.Builder.Integration.AspNet.Core
+{
+    public static class BotFrameworkOptionsTurnErrorExtensions
+    {
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILoggerFactory loggerFactory) =>
+            options.LogUnhandledTurnExceptions(loggerFactory.CreateLogger("Bot.TurnError"));
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILogger logger)
+        {
+            options.OnTurnError = (context, exception) =>
+            {
+                logger.LogError("An unexpected exception occurred while processing turn: {Exception}", exception);
+
+                return Task.CompletedTask;
+            };
+
+            return options;
+        }
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILoggerFactory loggerFactory, string friendlyErrorMessage) =>
+            options.LogUnhandledTurnExceptions(loggerFactory.CreateLogger("Bot.TurnError"), friendlyErrorMessage);
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILogger logger, string friendlyErrorMessage) =>
+            options.LogUnhandledTurnExceptions(logger, MessageFactory.Text(friendlyErrorMessage));
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILoggerFactory loggerFactory, Activity errorActivity) =>
+            options.LogUnhandledTurnExceptions(loggerFactory.CreateLogger("Bot.TurnError"), errorActivity);
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILogger logger, Activity errorActivity) =>
+            options.LogUnhandledTurnExceptions(logger, _ => errorActivity);
+
+        public static BotFrameworkOptions LogUnhandledTurnExceptions(this BotFrameworkOptions options, ILogger logger, Func<ITurnContext, Activity> errorActivityProvider)
+        {
+            if (logger == null)
+            {
+                throw new ArgumentNullException(nameof(logger));
+            }
+
+            if (errorActivityProvider == null)
+            {
+                throw new ArgumentNullException(nameof(errorActivityProvider));
+            }
+
+            options.OnTurnError = async (context, exception) =>
+            {
+                logger.LogError("An unexpected exception occurred while processing turn: ChannelId={ChannelId};From={FromId};Exception={Exception}", context.Activity.ChannelId, context.Activity.From.Id exception);
+
+                await context.SendActivityAsync(errorActivityProvider(context));
+            };
+
+            return options;
+        }
+    }
+}


### PR DESCRIPTION
Progressive walk through of configuring the turn error handler starting from the approach proposed in the samples going up through a set of new `BotFrameworkOptions` extension methods that provide the majority of boilerplate for the typical developer.